### PR TITLE
Use DB_HOST from the environment

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -100,7 +100,7 @@ DB_NAME=${DB_NAME:-librenms}
 
 sed -i -e "s/\$config\['db_pass'\] = .*;/\$config\['db_pass'\] = \"$DB_PASS\";/g" /data/config/config.php
 sed -i -e "s/\$config\['db_user'\] = .*;/\$config\['db_user'\] = \"$DB_USER\";/g" /data/config/config.php
-sed -i -e "s/\$config\['db_host'\] = .*;/\$config\['db_host'\] = \"mysql\";/g" /data/config/config.php
+sed -i -e "s/\$config\['db_host'\] = .*;/\$config\['db_host'\] = \"$DB_HOST\";/g" /data/config/config.php
 sed -i -e "s/\$config\['db_name'\] = .*;/\$config\['db_name'\] = \"$DB_NAME\";/g" /data/config/config.php
 sed -i "/\$config\['rrd_dir'\].*;/d" /data/config/config.php
 sed -i "/\$config\['log_file'\].*;/d" /data/config/config.php


### PR DESCRIPTION
The `DB_HOST` environment variable should be respected so external database hosts may be used. The defaults set from the docker link do expect the link to be named `mysql` and will still work as the `DB_HOST` variable is set appropriately beforehand.