### PR TITLE
LDAP support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /.project
+/data/
+/mysql/

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 /.idea/
 /data/
 /mysql/
-/docker-compose-rherzog.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /.project
+/.idea/
 /data/
 /mysql/
+/docker-compose-rherzog.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,10 @@ ENV HOME=/root \
 	LANG=en_US.UTF-8 \
 	LANGUAGE=en_US.UTF-8
 
-COPY init.sh /etc/my_init.d/init.sh
 COPY php-fpm.sh /etc/service/php-fpm/run
 COPY nginx.sh /etc/service/nginx/run
 COPY rrdcached.sh /etc/service/rrdcached/run
-
-# Use baseimage-docker's init system
-CMD ["/sbin/my_init"]
+COPY innodb.cnf /etc/mysql/conf.d/innodb.cnf
 
 RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends && \
 	echo 'APT::Install-Suggests 0;' >> /etc/apt/apt.conf.d/01norecommends && \
@@ -23,15 +20,23 @@ RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends && \
 	apt-get install -y \
 		php7.0-cli php7.0-mysql php7.0-gd php7.0-snmp php-pear php7.0-curl php-memcached \
 		php7.0-fpm snmp graphviz php7.0-mcrypt php7.0-json php7.0-opcache nginx-full fping \
-		imagemagick whois mtr-tiny nmap python-mysqldb snmpd php-net-ipv4 \
+		imagemagick whois mtr-tiny nmap python-mysqldb snmpd php-net-ipv4 php7.0-ldap \
 		php-net-ipv6 php-imagick rrdtool rrdcached git at mysql-client && \
 	phpenmod mcrypt && \
-	useradd librenms -d /opt/librenms -M -r && usermod -a -G librenms www-data && \
+	apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+	
+RUN	useradd librenms -d /opt/librenms -M -r && usermod -a -G librenms www-data && \
 	rm -rf /etc/service/sshd /etc/my_init.d/00_regen_ssh_host_keys.sh && \
 	locale-gen de_DE.UTF-8 && locale-gen en_US.UTF-8 && \
-	apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-	mkdir -p /data/logs /data/rrd /data/config /run/php /var/run/rrdcached && \
-    cd /opt && \
+	mkdir -p /data/logs /data/rrd /data/config /run/php /var/run/rrdcached
+
+
+COPY init.sh /etc/my_init.d/init.sh
+
+# Use baseimage-docker's init system
+CMD ["/sbin/my_init"]
+
+RUN cd /opt && \
 	chmod +x /etc/my_init.d/init.sh && \
 	chmod +x /etc/service/nginx/run && \
 	chmod +x /etc/service/php-fpm/run && \

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Usage example
 docker-compose up -d
 ```
 
+### with docker-compose + LDAP
+
+```bash
+docker-compose -f docker-compose-ldap.yml up -d
+```
+
 ### with sameersbn/mysql as database
 
 ```bash

--- a/docker-compose-ldap.yml
+++ b/docker-compose-ldap.yml
@@ -1,0 +1,51 @@
+version: '3'
+
+services:
+  mysql:
+    image: mariadb
+    container_name: librenms-db
+    volumes:
+      - ./mysql:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=pwd4librenms
+    restart: always
+
+  librenms:
+    build: .
+    image: seti/librenms
+    container_name: librenms
+    volumes:
+      - ./data:/data
+    ports:
+      - 80:80
+    depends_on:
+      - mysql
+    environment:
+      - DB_TYPE=mysql
+      - DB_HOST=mysql
+      - DB_NAME=librenms
+      - DB_USER=root
+      - DB_PASS=pwd4librenms
+      - TZ="Europe/Berlin"
+      - POLLER=24
+      # LDAP support
+      - LDAP_ENABLED=1
+      - LDAP_VERSION=3
+      - LDAP_SERVER=ldap.example.com
+      - LDAP_PORT=389
+      - LDAP_PREFIX=uid=
+      - LDAP_SUFFIX=,ou=People,dc=example,dc=com
+      # LDAP group check
+      - LDAP_GROUP=cn=groupname,ou=groups,dc=example,dc=com
+      - LDAP_GROUP_BASE=ou=group,dc=example,dc=com
+      - LDAP_GROUP_MEMBER_ATTR=uid
+      # Only if using LDAP auth bind
+      # Feature request as of 2017-09-02
+      # See https://github.com/librenms/librenms/issues/5089
+      # and https://community.librenms.org/t/feature-request-ldap-enhancements-bind-recursive-ssl/679
+      - LDAP_AUTH_BIND=0
+      - LDAP_BIND_USER=cn=librenms,ou=application,dc=example,dc=com
+      - LDAP_BIND_PASSWORD=pwd4librenms
+    restart: always
+      
+      

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,12 @@ services:
     container_name: librenms-db
     volumes:
       - ./mysql:/var/lib/mysql
-      - ./innodb.cnf:/etc/mysql/conf.d/innodb.cnf
     environment:
       - MYSQL_ROOT_PASSWORD=pwd4librenms
+    restart: always
   librenms:
     build: .
+    image: seti/librenms
     container_name: librenms
     volumes:
       - ./data:/data
@@ -21,9 +22,29 @@ services:
     environment:
       - DB_TYPE=mysql
       - DB_HOST=mysql
-      - DB_NAME=root
+      - DB_NAME=librenms
       - DB_USER=root
       - DB_PASS=pwd4librenms
       - TZ="Europe/Berlin"
       - POLLER=24
-
+      # LDAP support
+      - LDAP_ENABLED=1
+      - LDAP_VERSION=3
+      - LDAP_SERVER=ldap.example.com
+      - LDAP_PORT=389
+      - LDAP_PREFIX=uid=
+      - LDAP_SUFFIX=,ou=People,dc=example,dc=com
+      # LDAP group check
+      - LDAP_GROUP=cn=groupname,ou=groups,dc=example,dc=com
+      - LDAP_GROUP_BASE=ou=group,dc=example,dc=com
+      - LDAP_GROUP_MEMBER_ATTR=uid
+      # Only if using LDAP auth bind
+      # Feature request as of 2017-09-02
+      # See https://github.com/librenms/librenms/issues/5089
+      # and https://community.librenms.org/t/feature-request-ldap-enhancements-bind-recursive-ssl/679
+      - LDAP_AUTH_BIND=0
+      - LDAP_BIND_USER=cn=librenms,ou=application,dc=example,dc=com
+      - LDAP_BIND_PASSWORD=pwd4librenms
+    restart: always
+      
+      

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     environment:
       - MYSQL_ROOT_PASSWORD=pwd4librenms
     restart: always
+
   librenms:
     build: .
     image: seti/librenms
@@ -16,7 +17,7 @@ services:
     volumes:
       - ./data:/data
     ports:
-      - 8080:80
+      - 80:80
     depends_on:
       - mysql
     environment:
@@ -27,24 +28,6 @@ services:
       - DB_PASS=pwd4librenms
       - TZ="Europe/Berlin"
       - POLLER=24
-      # LDAP support
-      - LDAP_ENABLED=1
-      - LDAP_VERSION=3
-      - LDAP_SERVER=ldap.example.com
-      - LDAP_PORT=389
-      - LDAP_PREFIX=uid=
-      - LDAP_SUFFIX=,ou=People,dc=example,dc=com
-      # LDAP group check
-      - LDAP_GROUP=cn=groupname,ou=groups,dc=example,dc=com
-      - LDAP_GROUP_BASE=ou=group,dc=example,dc=com
-      - LDAP_GROUP_MEMBER_ATTR=uid
-      # Only if using LDAP auth bind
-      # Feature request as of 2017-09-02
-      # See https://github.com/librenms/librenms/issues/5089
-      # and https://community.librenms.org/t/feature-request-ldap-enhancements-bind-recursive-ssl/679
-      - LDAP_AUTH_BIND=0
-      - LDAP_BIND_USER=cn=librenms,ou=application,dc=example,dc=com
-      - LDAP_BIND_PASSWORD=pwd4librenms
     restart: always
       
       

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3'
+
+services:
+  mysql:
+    image: mariadb
+    container_name: librenms-db
+    volumes:
+      - ./mysql:/var/lib/mysql
+      - ./innodb.cnf:/etc/mysql/conf.d/innodb.cnf
+    environment:
+      - MYSQL_ROOT_PASSWORD=pwd4librenms
+  librenms:
+    build: .
+    container_name: librenms
+    volumes:
+      - ./data:/data
+    ports:
+      - 8080:80
+    depends_on:
+      - mysql
+    environment:
+      - DB_TYPE=mysql
+      - DB_HOST=mysql
+      - DB_NAME=root
+      - DB_USER=root
+      - DB_PASS=pwd4librenms
+      - TZ="Europe/Berlin"
+      - POLLER=24
+

--- a/innodb.cnf
+++ b/innodb.cnf
@@ -1,0 +1,4 @@
+[mysqld]
+innodb_buffer_pool_size = 8192M
+innodb_file_per_table=1
+sql_mode=NO_ENGINE_SUBSTITUTION


### PR DESCRIPTION
Hi and thanks a lot for this well prepared repo.

Here is ldap support for the librenms docker image. Unfortunately without auth bind option which is still a feature request. [librenms Issue #5089](https://github.com/librenms/librenms/issues/5089)
The ldap directory structure was a little bit tricky to set up but works for me now. If wanted, I can provide instructions how to set up the ldap structure and the correct groups/memberships.

Other changes:
- Default database server is now mariadb since [sameersbn/mysql](https://hub.docker.com/r/sameersbn/mysql/) is about 7 months old
- docker-compose.yml added
- DIR variable replaced by \`pwd\`
- innodb.cnf was statically created and moved into image build (see Dockerfile)
- Separate RUN commands in Dockerfile to speed up build process if files (eg. init.sh) is changed