### PR TITLE
Fix: mariadb config file mounted to container

### DIFF
--- a/50-server.cnf
+++ b/50-server.cnf
@@ -1,0 +1,4 @@
+[mysqld]
+innodb_file_per_table=1
+sql-mode=""
+lower_case_table_names=0

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ ENV HOME=/root \
 COPY php-fpm.sh /etc/service/php-fpm/run
 COPY nginx.sh /etc/service/nginx/run
 COPY rrdcached.sh /etc/service/rrdcached/run
-COPY innodb.cnf /etc/mysql/conf.d/innodb.cnf
 
 RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends && \
 	echo 'APT::Install-Suggests 0;' >> /etc/apt/apt.conf.d/01norecommends && \

--- a/README.md
+++ b/README.md
@@ -43,11 +43,12 @@ docker-compose up -d
 docker-compose -f docker-compose-ldap.yml up -d
 ```
 
-### with sameersbn/mysql as database
+### with mariadb as database
 
 ```bash
 docker run -d -m 1g \
 	-v `pwd`/mysql:/var/lib/mysql \
+	-v `pwd`/50-server.cnf:/etc/mysql/mariadb.conf.d/50-server.cnf:ro \
 	-e MYSQL_ROOT_PASSWORD=pwd4librenms \
 	-e LDAP_ENABLED=1 \
 	-e LDAP_VERSION=3 \

--- a/docker-compose-ldap.yml
+++ b/docker-compose-ldap.yml
@@ -6,6 +6,7 @@ services:
     container_name: librenms-db
     volumes:
       - ./mysql:/var/lib/mysql
+      - ./50-server.cnf:/etc/mysql/mariadb.conf.d/50-server.cnf:ro
     environment:
       - MYSQL_ROOT_PASSWORD=pwd4librenms
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     container_name: librenms-db
     volumes:
       - ./mysql:/var/lib/mysql
+      - ./50-server.cnf:/etc/mysql/mariadb.conf.d/50-server.cnf:ro
     environment:
       - MYSQL_ROOT_PASSWORD=pwd4librenms
     restart: always

--- a/innodb.cnf
+++ b/innodb.cnf
@@ -1,4 +1,0 @@
-[mysqld]
-innodb_buffer_pool_size = 8192M
-innodb_file_per_table=1
-sql_mode=NO_ENGINE_SUBSTITUTION


### PR DESCRIPTION
- Removed innodb.cnf from image
- Added 50-server.cnf mounted inside mariadb container as described [here](https://docs.librenms.org/Installation/Installation-Ubuntu-1604-Nginx/#install-configure-mysql)