### PR TITLE
Add syslog-ng support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends && \
 	apt-get install -y \
 		composer php7.0-cli php7.0-mysql php7.0-gd php7.0-snmp php-pear php7.0-curl php-memcached \
 		php7.0-fpm snmp graphviz php7.0-mcrypt php7.0-json php7.0-opcache nginx-full fping \
-		imagemagick whois mtr-tiny nmap python-mysqldb snmpd php-net-ipv4 php7.0-ldap \
+		imagemagick whois mtr-tiny nmap python-mysqldb snmpd php-net-ipv4 php7.0-ldap syslog-ng \
 		php-net-ipv6 php-imagick rrdtool rrdcached git at mysql-client nagios-plugins sudo \
         memcached php7.0-xml php7.0-zip python-memcache && \
 	phpenmod mcrypt && \
@@ -36,6 +36,7 @@ COPY php-fpm.sh /etc/service/php-fpm/run
 COPY nginx.sh /etc/service/nginx/run
 COPY rrdcached.sh /opt/services/rrdcached/run
 COPY memcached.sh /opt/services/memcached/run
+COPY syslog-ng.conf /etc/syslog-ng/syslog-ng.conf
 
 RUN cd /opt && \
 	chmod +x /etc/my_init.d/init.sh && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       - ./data:/data
     ports:
       - 80:80
+      - 514:514/tcp
+      - 514:514/udp
     depends_on:
       - mysql
     environment:
@@ -32,4 +34,5 @@ services:
       - POLLER=24
       - SERVICES_ENABLED=1
       - UPDATE_CHANNEL=master
+      - SYSLOG_ENABLED=1
     restart: always

--- a/init.sh
+++ b/init.sh
@@ -19,7 +19,7 @@ if [ ! -d /opt/librenms ]; then
 	git clone https://github.com/librenms/librenms.git librenms
 	rm -rf /opt/librenms/html/plugins
 	cd /opt/librenms
-	
+
 	ln -s /data/rrd /opt/librenms/rrd
 	ln -s /data/plugins /opt/librenms/html/plugins
 	ln -s /data/logs /opt/librenms/logs
@@ -151,12 +151,19 @@ then
   echo "\$config['nagios_plugins'] = \"/usr/lib/nagios/plugins\";" >> /data/config/config.php
 fi
 
+# Enable syslog
+SYSLOG_ENABLED=${SYSLOG_ENABLED:-0}
+if [ "${SYSLOG_ENABLED}" == "1" ]
+then
+  echo "\$config['enable_syslog'] = 1;" >> /data/config/config.php
+fi
+
 # LDAP support
 LDAP_ENABLED=${LDAP_ENABLED:-0}
 if [ "${LDAP_ENABLED}" == "1" ]
 then
   echo "setup ldap support"
-  
+
   LDAP_VERSION=${LDAP_VERSION:-3}
   LDAP_SERVER=${LDAP_SERVER:-ldap.example.com}
   LDAP_PORT=${LDAP_PORT:-389}
@@ -180,13 +187,13 @@ then
 
   sed -i "/\$config\['auth_ldap_suffix'\].*;/d" /data/config/config.php
   echo "\$config['auth_ldap_suffix']                      = \"${LDAP_SUFFIX}\";" >> /data/config/config.php
-  
-  
+
+
   LDAP_GROUP=${LDAP_GROUP:-cn=groupname,ou=groups,dc=example,dc=com}
   LDAP_GROUP_BASE=${LDAP_GROUP_BASE:-ou=group,dc=example,dc=com}
   LDAP_GROUP_MEMBER_ATTR=${LDAP_GROUP_MEMBER_ATTR:-member}
   LDAP_GROUP_MEMBER_TYPE=${LDAP_GROUP_MEMBER_TYPE:-}
-  
+
   sed -i "/\$config\['auth_ldap_group'\].*;/d" /data/config/config.php
   if [ "${LDAP_GROUP}" == "false" ]; then
     echo "\$config['auth_ldap_group']                       = false;" >> /data/config/config.php

--- a/syslog-ng.conf
+++ b/syslog-ng.conf
@@ -1,0 +1,70 @@
+@version:3.5
+@include "scl.conf"
+
+# syslog-ng configuration file.
+#
+# This should behave pretty much like the original syslog on RedHat. But
+# it could be configured a lot smarter.
+#
+# See syslog-ng(8) and syslog-ng.conf(5) for more information.
+#
+# Note: it also sources additional configuration files (*.conf)
+#       located in /etc/syslog-ng/conf.d/
+
+options {
+        chain_hostnames(off);
+        flush_lines(0);
+        use_dns(no);
+        use_fqdn(no);
+        owner("root");
+        group("adm");
+        perm(0640);
+        stats_freq(0);
+        bad_hostname("^gconfd$");
+};
+
+
+source s_sys {
+    # system();
+    internal();
+
+};
+
+source s_net {
+        tcp(port(514) flags(syslog-protocol));
+        udp(port(514) flags(syslog-protocol));
+};
+
+
+########################
+# Destinations
+########################
+destination d_librenms {
+        program("/opt/librenms/syslog.php" template ("$HOST||$FACILITY||$PRIORITY||$LEVEL||$TAG||$R_YEAR-$R_MONTH-$R_DAY $R_HOUR:$R_MIN:$R_SEC||$MSG||$PROGRAM\n") template-escape(yes));
+};
+
+filter f_kernel     { facility(kern); };
+filter f_default    { level(info..emerg) and
+                        not (facility(mail)
+                        or facility(authpriv)
+                        or facility(cron)); };
+filter f_auth       { facility(authpriv); };
+filter f_mail       { facility(mail); };
+filter f_emergency  { level(emerg); };
+filter f_news       { facility(uucp) or
+                        (facility(news)
+                        and level(crit..emerg)); };
+filter f_boot   { facility(local7); };
+filter f_cron   { facility(cron); };
+
+########################
+# Log paths
+########################
+log {
+        source(s_net);
+        source(s_sys);
+        destination(d_librenms);
+};
+
+# Source additional configuration files (.conf extension only)
+@include "/etc/syslog-ng/conf.d/*.conf"


### PR DESCRIPTION
I noticed a pretty critical network monitoring component was not enabled in from this docker image.

I went ahead and added syslog-ng support. Unfortunately, just adding a syslog-ng container on top of the ecosystem does not work as it depends on scripts running on the host container to work properly.

Please consider this PR as syslog support to track logging on devices is critical for a healthy infrastructure (and sane network admin).