### PR TITLE
Ceph service support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.idea/
 /data/
 /mysql/
+/ceph/

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends && \
 		php7.0-fpm snmp graphviz php7.0-mcrypt php7.0-json php7.0-opcache nginx-full fping \
 		imagemagick whois mtr-tiny nmap python-mysqldb snmpd php-net-ipv4 php7.0-ldap syslog-ng \
 		php-net-ipv6 php-imagick rrdtool rrdcached git at mysql-client nagios-plugins sudo \
-        memcached php7.0-xml php7.0-zip python-memcache && \
+        memcached php7.0-xml php7.0-zip python-memcache make && \
 	phpenmod mcrypt && \
 	apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ LibreNMS
 ---
 Last Changes
 ===
+- 2018/04/30: Added ceph service support
 - 2018/02/09: Update to Phusion Baseimage 0.10.0 & added composer
 - 2017/12/14: Support for distributed poller nodes
 - 2017/10/31: ldap auth bind support added
@@ -53,6 +54,12 @@ docker-compose -f docker-compose-ldap.yml up -d
 
 ```bash
 docker-compose -f docker-compose-distributed-poller.yml up -d
+```
+
+### with docker-compose + ceph support
+
+```bash
+docker-compose -f docker-compose-ceph.yml up -d
 ```
 
 ### with mariadb as database

--- a/docker-compose-ceph.yml
+++ b/docker-compose-ceph.yml
@@ -1,0 +1,42 @@
+version: '3'
+
+services:
+  mysql:
+    image: mariadb
+    container_name: librenms-db
+    volumes:
+      - ./mysql:/var/lib/mysql
+      - ./50-server.cnf:/etc/mysql/mariadb.conf.d/50-server.cnf:ro
+    environment:
+      - MYSQL_ROOT_PASSWORD=pwd4librenms
+    restart: always
+
+  librenms:
+    build: .
+    image: seti/librenms
+    container_name: librenms
+    hostname: librenms
+    volumes:
+      - ./data:/data
+      # ceph/ should contain ceph.conf and client keyring to use for service
+      - ./ceph:/etc/ceph
+    ports:
+      - 80:80
+      - 514:514/tcp
+      - 514:514/udp
+    depends_on:
+      - mysql
+    environment:
+      - DB_TYPE=mysql
+      - DB_HOST=mysql
+      - DB_NAME=librenms
+      - DB_USER=root
+      - DB_PASS=pwd4librenms
+      - TZ="Europe/Berlin"
+      - POLLER=24
+      - SERVICES_ENABLED=1
+      - UPDATE_CHANNEL=master
+      - SYSLOG_ENABLED=1
+      - CEPH_ENABLED=1
+      - CEPH_RELEASE=luminous # Optional
+    restart: always

--- a/docker-compose-ceph.yml
+++ b/docker-compose-ceph.yml
@@ -18,7 +18,7 @@ services:
     hostname: librenms
     volumes:
       - ./data:/data
-      # ceph/ should contain ceph.conf and client keyring to use for service
+      # ./ceph/ should contain ceph.conf and client keyring to use for service
       - ./ceph:/etc/ceph
     ports:
       - 80:80

--- a/init.sh
+++ b/init.sh
@@ -236,6 +236,31 @@ then
   fi
 fi
 
+CEPH_ENABLED=${CEPH_ENABLED:-0}
+CEPH_RELEASE=${CEPH_RELEASE:-luminous}
+if [ "${CEPH_ENABLED}" == "1" ]; then
+    echo "Clone ceph-nagios-plugins repo from github."
+    cd /opt
+    git clone https://github.com/ceph/ceph-nagios-plugins.git ceph-nagios-plugins
+
+    echo "Install ceph-nagios-plugins"
+    cd /opt/ceph-nagios-plugins
+    make install
+
+    echo "Install ceph binaries"
+
+    # http://docs.ceph.com/docs/master/install/get-packages/
+    # Import release key
+    curl -o - --silent 'https://download.ceph.com/keys/release.asc' | apt-key add -
+
+    # Add official deb repo
+    apt-add-repository "deb https://download.ceph.com/debian-${CEPH_RELEASE}/ $(lsb_release -sc) main"
+
+    # Update and install ceph
+    apt-get update -qq
+    apt-get install -y -q ceph-common > /dev/null
+fi
+
 # some php configs
 sed -i 's/pm.max_children = 5/pm.max_children = 50/g' /etc/php/7.0/fpm/pool.d/www.conf
 sed -i 's/pm.start_servers = 2/pm.start_servers = 5/g' /etc/php/7.0/fpm/pool.d/www.conf


### PR DESCRIPTION
Here is the support for ceph service monitoring.

One thing which is not entirely nice, is the "on container start" installation of the ceph binaries. I decided to do this for keeping the image smaller for ones who does not use it and the ability to install a specific version of ceph (which might be older than current default luminous).