### PR TITLE
Add ipmitool to enable IPMI sensor polling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends && \
 		acl composer php7.2-mbstring php7.2-cli php7.2-mysql php7.2-gd php7.2-snmp php-pear php7.2-curl php-memcached \
 		php7.2-fpm snmp graphviz php7.2-json php7.2-opcache nginx-full fping \
 		imagemagick whois mtr-tiny nmap python-mysqldb snmpd php7.2-ldap syslog-ng \
-		php-net-ipv6 php-imagick rrdtool rrdcached git at mysql-client nagios-plugins sudo \
+		php-net-ipv6 php-imagick rrdtool rrdcached git at mysql-client nagios-plugins sudo ipmitool \
         memcached php7.2-xml php7.2-zip python-memcache make && \
 	apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Just noticed that IPMI polling wasn't working for my container, and found that this package was missing.  This PR should address that for folks that want/need this functionality.